### PR TITLE
fix: AVAudioPlayer cannot play on background when Youtube playing

### DIFF
--- a/src/ios/APPBackgroundMode.m
+++ b/src/ios/APPBackgroundMode.m
@@ -213,8 +213,10 @@ NSString* const kAPPBackgroundEventDeactivate = @"deactivate";
 
     // Play music even in background and dont stop playing music
     // even another app starts playing sound
-    [session setCategory:AVAudioSessionCategoryPlayback
-                   error:NULL];
+//     [session setCategory:AVAudioSessionCategoryPlayback
+//                    error:NULL];
+
+    [session setCategory:AVAudioSessionCategoryPlayback withOptions:AVAudioSessionCategoryOptionMixWithOthers error:nil];
 
     // Active the audio session
     [session setActive:YES error:NULL];


### PR DESCRIPTION
AVAudioPlayer cannot play on background when Youtube playing